### PR TITLE
feat: Add GitHub Actions workflow for Docusaurus deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy Docusaurus to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions: # Add this to allow the job to write to the gh-pages branch
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install pnpm and dependencies
+        run: |
+          npm install -g pnpm
+          pnpm install
+      - name: Build Docusaurus site
+        run: pnpm --filter docs build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/build
+          # cname: your-custom-domain.com # Optional: if you have a custom domain


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow that automates the deployment of the Docusaurus site to GitHub Pages.

The workflow is triggered on pushes to the `main` branch and performs the following steps:
1. Checks out the repository code.
2. Sets up Node.js version 18.
3. Installs pnpm.
4. Installs project dependencies using `pnpm install`.
5. Builds the Docusaurus site located in the `docs` workspace using `pnpm --filter docs build`.
6. Deploys the built site from the `docs/build` directory to the `gh-pages` branch using the `peaceiris/actions-gh-pages@v3` action.

The workflow includes necessary permissions for the `GITHUB_TOKEN` to allow writing to the `gh-pages` branch.